### PR TITLE
Fix the build + tests under non little-endian archs

### DIFF
--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -27,7 +27,7 @@ pub(crate) fn keccakf_u8(st: &mut AlignedKeccakState) {
 #[cfg(not(target_endian = "little"))]
 pub(crate) fn keccakf_u8(st: &mut AlignedKeccakState) {
     let mut keccak_block = [0u64; KECCAK_BLOCK_SIZE];
-    LittleEndian::read_u64_into(st.0, &mut keccak_block);
+    LittleEndian::read_u64_into(&st.0, &mut keccak_block);
     tiny_keccak::keccakf(&mut keccak_block);
     LittleEndian::write_u64_into(&keccak_block, &mut st.0);
 }


### PR DESCRIPTION
Testing the build with `cross test --target powerpc-unknown-linux-gnu` results in the following:
https://gist.github.com/e0e56e236ea832ea7fc70da2e92049e1

See cross: https://github.com/rust-embedded/cross

Relatedly, the powerpc build is not tested in CI.