### PR TITLE
Add ZeroizeOnDrop support for Strobe.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ keccak = "0.1"
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.3", optional = true }
 subtle = { version = "2.4", default-features = false }
+zeroize = { version = "1.5", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -1,4 +1,5 @@
 use byteorder::{ByteOrder, LittleEndian};
+use zeroize::Zeroize;
 
 /// keccak block size in 64-bit words. This is the N parameter in the STROBE spec
 pub const KECCAK_BLOCK_SIZE: usize = 25;
@@ -14,7 +15,7 @@ big_array! { BigArray; 8 * KECCAK_BLOCK_SIZE }
 
 /// This is a wrapper around 200-byte buffer that's always 8-byte aligned to make pointers to it
 /// safely convertible to a pointer to [u64; 25] (since u64 words must be 8-byte aligned)
-#[derive(Clone)]
+#[derive(Clone, Zeroize)]
 #[cfg_attr(feature = "serialize_secret_state", derive(Serialize, Deserialize))]
 #[repr(align(8))]
 pub(crate) struct AlignedKeccakState(

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use bitflags::bitflags;
 use subtle::{self, ConstantTimeEq};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // With this feature on, a user can serialize and deserialize the state of a STROBE session
 #[cfg(feature = "serialize_secret_state")]
@@ -30,6 +30,12 @@ bitflags! {
         const M = 1<<4;
         /// Reserved and currently unimplemented. Using this will cause a panic.
         const K = 1<<5;
+    }
+}
+
+impl Zeroize for OpFlags {
+    fn zeroize(&mut self) {
+        self.bits.zeroize()
     }
 }
 
@@ -103,7 +109,6 @@ pub struct Strobe {
     is_receiver: Option<bool>,
     /// The last operation performed. This is to verify that the `more` flag is only used across
     /// identical operations.
-    #[zeroize(skip)]
     prev_flags: Option<OpFlags>,
 }
 

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use bitflags::bitflags;
 use subtle::{self, ConstantTimeEq};
+use zeroize::ZeroizeOnDrop;
 
 // With this feature on, a user can serialize and deserialize the state of a STROBE session
 #[cfg(feature = "serialize_secret_state")]
@@ -84,12 +85,13 @@ pub struct AuthError;
 ///
 /// Finally, `ratchet` and `meta_ratchet` take a `usize` argument instead of bytes. These functions
 /// are individually commented below.
-#[derive(Clone)]
+#[derive(Clone, ZeroizeOnDrop)]
 #[cfg_attr(feature = "serialize_secret_state", derive(Serialize, Deserialize))]
 pub struct Strobe {
     /// Internal Keccak state
     pub(crate) st: AlignedKeccakState,
     /// Security parameter (128 or 256)
+    #[zeroize(skip)]
     sec: SecParam,
     /// This is the `R` parameter in the Strobe spec
     rate: usize,
@@ -101,6 +103,7 @@ pub struct Strobe {
     is_receiver: Option<bool>,
     /// The last operation performed. This is to verify that the `more` flag is only used across
     /// identical operations.
+    #[zeroize(skip)]
     prev_flags: Option<OpFlags>,
 }
 


### PR DESCRIPTION
This adds a derived `ZeroizeOnDrop` implementation for `Strobe`, allowing for the state to be securely erased in memory once an instance is dropped.