### PR TITLE
Add StrobeRng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ zeroize = { version = "1.5", features = ["derive"] }
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 hex = "0.4"
+rand = { version = "0.8", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [features]
 default = []
+rand = ["rand_core"]
 std = []
 serialize_secret_state = ["serde", "serde-big-array"]
 
@@ -20,6 +21,7 @@ serialize_secret_state = ["serde", "serde-big-array"]
 bitflags = "1.3"
 byteorder = { version = "1.4", default-features = false }
 keccak = "0.1"
+rand_core = { version = "0.6.4", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.4", optional = true }
 subtle = { version = "2.4", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ mod basic_tests;
 #[cfg(all(test, feature = "std"))]
 mod kat_tests;
 
+#[cfg(all(test, feature = "rand"))]
+mod rand_tests;
+
 //-------- Modules and exports--------//
 
 mod keccak;
@@ -72,4 +75,4 @@ pub use crate::strobe::*;
 mod rand;
 
 #[cfg(feature = "rand")]
-pub use rand::StrobeRng;
+pub use crate::rand::StrobeRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,3 +67,9 @@ mod keccak;
 mod strobe;
 
 pub use crate::strobe::*;
+
+#[cfg(feature = "rand")]
+mod rand;
+
+#[cfg(feature = "rand")]
+pub use rand::StrobeRng;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,0 +1,41 @@
+/// RngCore impl for the Strobe hash
+
+use rand_core::{CryptoRng, RngCore};
+use crate::Strobe;
+
+/// StrobeRng implements the RngCore trait by using STROBE as an entropy pool
+pub struct StrobeRng {
+  strobe: Strobe,
+}
+
+impl From<Strobe> for StrobeRng {
+  fn from(strobe: Strobe) -> Self {
+    StrobeRng { strobe }
+  }
+}
+
+impl RngCore for StrobeRng {
+  fn next_u32(&mut self) -> u32 {
+    rand_core::impls::next_u32_via_fill(self)
+  }
+
+  fn next_u64(&mut self) -> u64 {
+    rand_core::impls::next_u64_via_fill(self)
+  }
+
+  fn fill_bytes(&mut self, dest: &mut [u8]) {
+    let dest_len = (dest.len() as u32).to_le_bytes();
+    self.strobe.meta_ad(&dest_len, false);
+    self.strobe.prf(dest, false);
+  }
+
+  fn try_fill_bytes(
+    &mut self,
+    dest: &mut [u8],
+  ) -> Result<(), rand_core::Error> {
+    self.fill_bytes(dest);
+    Ok(())
+  }
+}
+
+impl CryptoRng for StrobeRng {}

--- a/src/rand_tests.rs
+++ b/src/rand_tests.rs
@@ -1,0 +1,25 @@
+//! tests for the `rand` feature
+
+use crate::{SecParam, Strobe, StrobeRng};
+use rand::{Rng, rngs::OsRng};
+
+#[derive(Debug, Default)]
+struct Key([u8; 32]);
+
+fn random_key<R: Rng>(rng: &mut R) -> Key {
+    let mut key: Key = Default::default();
+    rng.fill(key.0.as_mut_slice());
+    key
+}
+
+#[test]
+fn from_strobe() {
+    let mut t = Strobe::new(b"StrobeRng test", SecParam::B128);
+    let key = random_key(&mut OsRng);
+    t.key(&key.0, false);
+    let zero = [0u8; 128];
+    let mut rng: StrobeRng = t.into();
+    let mut output = zero.clone();
+    rng.fill(&mut output);
+    assert!(output != zero);
+}


### PR DESCRIPTION
 Implement a standard random number generator type `StrobeRng`, based on the strobe prf.
    
This allows interfacing with code using the normal `Rng` or `CryptoRng` traits. Availability is gated by the `rand` feature, off by default.

We use this in a [variety of crates](https://github.com/brave/sta-rs) and it would be nice to have support here so we don't have to duplicate the newtype each time.