### PR TITLE
Update to criterion v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1.5", features = ["derive"] }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Move the the latest release of the benchmark harness to address a `cargo audit` warning about the `atty` transitive dependency, which is unmaintained and unsound on MS Windows.
https://rustsec.org/advisories/RUSTSEC-2021-0145

No source changes are necessary.